### PR TITLE
Integrate MessageManager payment flow into chat send button

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,13 @@
-import React, { useState, useEffect, useRef } from 'react';
-import { useAccount, useSignMessage } from 'wagmi';
+import React, { useState, useEffect, useRef, useMemo } from 'react';
+import {
+  useAccount,
+  useSignMessage,
+  useSignTypedData,
+  usePublicClient,
+  useReadContract,
+  useWriteContract,
+  useChainId
+} from 'wagmi';
 import { Container, Row, Col } from 'react-bootstrap';
 import 'bootstrap/dist/css/bootstrap.min.css';
 import './bootstrap-overrides.css';
@@ -8,6 +16,17 @@ import './bootstrap-overrides.css';
 import Header from './components/layout/Header';
 import ChatContainer from './components/chat/ChatContainer';
 import AccountContainer from './components/account/AccountContainer';
+import { getContractAddress, ERC20_ABI } from './config/contracts';
+import MESSAGE_MANAGER_ABI from './config/abi/MessageManager.json';
+import {
+  MESSAGE_MANAGER_ADDRESS,
+  MESSAGE_MANAGER_DOMAIN_NAME,
+  MESSAGE_MANAGER_DOMAIN_VERSION,
+  MESSAGE_PRICE_USDC,
+  MESSAGE_TYPED_DATA,
+  MessagePayload
+} from './config/messageManager';
+import { hashTypedData, keccak256, stringToHex, zeroAddress } from 'viem';
 
 // Define types for messages
 interface Message {
@@ -26,11 +45,47 @@ const App: React.FC = () => {
   const [socket, setSocket] = useState<WebSocket | null>(null);
   const [connectionStatus, setConnectionStatus] = useState<'connected' | 'connecting' | 'disconnected'>('disconnected');
   const [isThinking, setIsThinking] = useState<boolean>(false);
+  const [isApproving, setIsApproving] = useState<boolean>(false);
+  const [isPaying, setIsPaying] = useState<boolean>(false);
   const messagesEndRef = useRef<HTMLDivElement>(null);
-  
+  const nonceCounterRef = useRef<number>(0);
+
   // Use wagmi's useAccount hook to check if wallet is connected
   const { address, isConnected } = useAccount();
+  const chainId = useChainId();
   const { signMessageAsync } = useSignMessage();
+  const { signTypedDataAsync } = useSignTypedData();
+  const publicClient = usePublicClient();
+  const { writeContractAsync } = useWriteContract();
+
+  const usdcAddress = useMemo(
+    () => (chainId ? getContractAddress(chainId, 'USDC') : undefined),
+    [chainId]
+  );
+
+  const {
+    data: allowance,
+    refetch: refetchAllowance,
+    isLoading: isAllowanceLoading
+  } = useReadContract({
+    address: usdcAddress ?? zeroAddress,
+    abi: ERC20_ABI,
+    functionName: 'allowance',
+    args: [address ?? zeroAddress, MESSAGE_MANAGER_ADDRESS],
+    query: {
+      enabled: Boolean(isConnected && address && usdcAddress)
+    }
+  });
+
+  const hasApproval = useMemo(() => {
+    const allowanceValue = allowance as bigint | undefined;
+    if (!allowanceValue) return false;
+    try {
+      return allowanceValue >= MESSAGE_PRICE_USDC;
+    } catch {
+      return false;
+    }
+  }, [allowance]);
 
   // Connect to WebSocket
   useEffect(() => {
@@ -131,55 +186,182 @@ const App: React.FC = () => {
     }
   }, [messages]);
 
+  const handleApprove = async (): Promise<void> => {
+    if (!address || !isConnected || !usdcAddress) {
+      setMessages(prev => [...prev, {
+        type: 'error',
+        content: 'Unable to approve USDC spending. Please ensure you are connected to a supported network.'
+      }]);
+      return;
+    }
+
+    setIsApproving(true);
+    try {
+      const txHash = await writeContractAsync({
+        address: usdcAddress,
+        abi: ERC20_ABI,
+        functionName: 'approve',
+        args: [MESSAGE_MANAGER_ADDRESS, MESSAGE_PRICE_USDC]
+      });
+
+      if (publicClient) {
+        await publicClient.waitForTransactionReceipt({ hash: txHash });
+      }
+      await refetchAllowance();
+    } catch (error) {
+      console.error('Error approving MessageManager spending:', error);
+      setMessages(prev => [...prev, {
+        type: 'error',
+        content: 'Approval transaction failed or was rejected. Please try again.'
+      }]);
+    } finally {
+      setIsApproving(false);
+    }
+  };
+
   const sendMessage = async (): Promise<void> => {
-    if (!input.trim() || connectionStatus !== 'connected' || isThinking || !socket) return;
-    
+    if (
+      !input.trim()
+      || connectionStatus !== 'connected'
+      || isThinking
+      || !socket
+      || !address
+      || !chainId
+    ) {
+      return;
+    }
+
+    if (!hasApproval) {
+      await handleApprove();
+      return;
+    }
+
+    setIsPaying(true);
+
     // Add user message to UI
     setMessages(prev => [...prev, { type: 'user', content: input }]);
-    
+
     // Add signature pending message
     setMessages(prev => [...prev, { type: 'signature_pending', content: 'Waiting for signature...' }]);
-    
+
     try {
-      // Sign the message with the connected wallet
-      const signature = await signMessageAsync({ message: input });
-      
+      // Sign the plain-text message for backend verification
+      const messageSignature = await signMessageAsync({ message: input });
+
+      const messageHash = keccak256(stringToHex(input));
+      nonceCounterRef.current = (nonceCounterRef.current + 1) % 1000;
+      const nonce = BigInt(Date.now()) * 1000n + BigInt(nonceCounterRef.current);
+      const payload: MessagePayload = {
+        messageHash,
+        payer: address,
+        nonce
+      };
+
+      const domain = {
+        name: MESSAGE_MANAGER_DOMAIN_NAME,
+        version: MESSAGE_MANAGER_DOMAIN_VERSION,
+        chainId,
+        verifyingContract: MESSAGE_MANAGER_ADDRESS
+      } as const;
+
+      const typedSignature = await signTypedDataAsync({
+        domain,
+        types: MESSAGE_TYPED_DATA,
+        primaryType: 'Message',
+        message: payload
+      });
+
+      const digest = hashTypedData({
+        domain,
+        types: MESSAGE_TYPED_DATA,
+        primaryType: 'Message',
+        message: payload
+      });
+
+      const txHash = await writeContractAsync({
+        address: MESSAGE_MANAGER_ADDRESS,
+        abi: MESSAGE_MANAGER_ABI,
+        functionName: 'payForMessageWithSig',
+        args: [payload, typedSignature, input]
+      });
+
+      if (publicClient) {
+        await publicClient.waitForTransactionReceipt({ hash: txHash });
+      }
+      await refetchAllowance();
+
       // Remove signature pending message and add thinking message
       setMessages(prev => {
         const filteredMessages = prev.filter(msg => msg.type !== 'signature_pending');
         return [...filteredMessages, { type: 'thinking', content: 'Thinking...' }];
       });
-      
-      // Set thinking state after signature is obtained
+
       setIsThinking(true);
-      
-      // Send signed message to server
-      socket.send(JSON.stringify({ 
+
+      socket.send(JSON.stringify({
         message: input,
-        signature: signature,
-        address: address
+        signature: messageSignature,
+        address,
+        payment: {
+          m: {
+            messageHash,
+            payer: address,
+            nonce: nonce.toString()
+          },
+          sig: typedSignature,
+          messageURI: input,
+          digest,
+          transactionHash: txHash
+        }
       }));
-      
-      // Clear input
+
       setInput('');
     } catch (error) {
-      console.error('Error signing message:', error);
+      console.error('Error paying for message:', error);
       setMessages(prev => {
-        // Remove signature pending message
         const filteredMessages = prev.filter(msg => msg.type !== 'signature_pending');
-        return [...filteredMessages, { 
-          type: 'error', 
-          content: 'Failed to sign message. Please try again.' 
+        return [...filteredMessages, {
+          type: 'error',
+          content: 'Failed to pay for and sign the message. Please try again.'
         }];
       });
+    } finally {
+      setIsPaying(false);
     }
   };
 
   // Update the handleKeyDown to be async
+  const buttonLabel = (() => {
+    if (isAllowanceLoading) {
+      return 'Checking approval...';
+    }
+    if (!hasApproval) {
+      return isApproving ? 'Approving...' : 'Approve';
+    }
+    return isPaying ? 'Paying...' : 'Pay and Sign Message';
+  })();
+
+  const buttonModeProcessing = !hasApproval ? isApproving : isPaying;
+  const buttonDisabled =
+    connectionStatus !== 'connected'
+    || isThinking
+    || buttonModeProcessing
+    || isAllowanceLoading
+    || (hasApproval && !input.trim());
+
+  const handlePrimaryAction = async (): Promise<void> => {
+    if (!hasApproval) {
+      await handleApprove();
+      return;
+    }
+    await sendMessage();
+  };
+
   const handleKeyDown = async (e: React.KeyboardEvent<HTMLTextAreaElement>): Promise<void> => {
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
-      await sendMessage();
+      if (buttonDisabled) return;
+      await handlePrimaryAction();
     }
   };
 
@@ -192,16 +374,19 @@ const App: React.FC = () => {
         <Row className="g-4">
           {/* Chat Container */}
           <Col lg={6}>
-            <ChatContainer 
+            <ChatContainer
               isConnected={isConnected}
               messages={messages}
               messagesEndRef={messagesEndRef}
               input={input}
               setInput={setInput}
               handleKeyDown={handleKeyDown}
-              sendMessage={sendMessage}
+              onPrimaryAction={handlePrimaryAction}
               connectionStatus={connectionStatus}
               isThinking={isThinking}
+              buttonLabel={buttonLabel}
+              isButtonDisabled={buttonDisabled}
+              isProcessingAction={buttonModeProcessing}
             />
           </Col>
           

--- a/frontend/src/components/chat/ChatContainer.tsx
+++ b/frontend/src/components/chat/ChatContainer.tsx
@@ -1,31 +1,59 @@
-import React from 'react';
+import React, { RefObject } from 'react';
 import { Card } from 'react-bootstrap';
 import MessageList from './MessageList';
 import MessageInput from './MessageInput';
 
-function ChatContainer({ 
-  isConnected, 
-  messages, 
-  messagesEndRef, 
+type ConnectionStatus = 'connected' | 'connecting' | 'disconnected';
+
+interface Message {
+  type: 'agent' | 'user' | 'thinking' | 'tool' | 'tool_call' | 'error' | 'signature_pending';
+  content: string;
+}
+
+interface ChatContainerProps {
+  isConnected: boolean;
+  messages: Message[];
+  messagesEndRef: RefObject<HTMLDivElement>;
+  input: string;
+  setInput: (value: string) => void;
+  handleKeyDown: (event: React.KeyboardEvent<HTMLTextAreaElement>) => Promise<void>;
+  onPrimaryAction: () => Promise<void>;
+  connectionStatus: ConnectionStatus;
+  isThinking: boolean;
+  buttonLabel: string;
+  isButtonDisabled: boolean;
+  isProcessingAction: boolean;
+}
+
+const ChatContainer: React.FC<ChatContainerProps> = ({
+  isConnected,
+  messages,
+  messagesEndRef,
   input,
   setInput,
   handleKeyDown,
-  sendMessage,
+  onPrimaryAction,
   connectionStatus,
-  isThinking
-}) {
+  isThinking,
+  buttonLabel,
+  isButtonDisabled,
+  isProcessingAction
+}) => {
   return (
     <Card className="h-100 chat-card">
       {isConnected ? (
         <>
           <MessageList messages={messages} messagesEndRef={messagesEndRef} />
-          <MessageInput 
+          <MessageInput
             input={input}
             setInput={setInput}
             handleKeyDown={handleKeyDown}
-            sendMessage={sendMessage}
+            onPrimaryAction={onPrimaryAction}
             connectionStatus={connectionStatus}
             isThinking={isThinking}
+            buttonLabel={buttonLabel}
+            isButtonDisabled={isButtonDisabled}
+            isProcessingAction={isProcessingAction}
           />
         </>
       ) : (
@@ -36,6 +64,6 @@ function ChatContainer({
       )}
     </Card>
   );
-}
+};
 
-export default ChatContainer; 
+export default ChatContainer;

--- a/frontend/src/components/chat/MessageInput.tsx
+++ b/frontend/src/components/chat/MessageInput.tsx
@@ -1,14 +1,33 @@
 import React from 'react';
-import { Form, Button, Card } from 'react-bootstrap';
+import { Form, Button, Card, Spinner } from 'react-bootstrap';
 
-function MessageInput({ 
-  input, 
-  setInput, 
-  handleKeyDown, 
-  sendMessage, 
-  connectionStatus, 
-  isThinking 
-}) {
+type ConnectionStatus = 'connected' | 'connecting' | 'disconnected';
+
+interface MessageInputProps {
+  input: string;
+  setInput: (value: string) => void;
+  handleKeyDown: (event: React.KeyboardEvent<HTMLTextAreaElement>) => Promise<void>;
+  onPrimaryAction: () => Promise<void>;
+  connectionStatus: ConnectionStatus;
+  isThinking: boolean;
+  buttonLabel: string;
+  isButtonDisabled: boolean;
+  isProcessingAction: boolean;
+}
+
+const MessageInput: React.FC<MessageInputProps> = ({
+  input,
+  setInput,
+  handleKeyDown,
+  onPrimaryAction,
+  connectionStatus,
+  isThinking,
+  buttonLabel,
+  isButtonDisabled,
+  isProcessingAction
+}) => {
+  const capitalizedStatus = connectionStatus.charAt(0).toUpperCase() + connectionStatus.slice(1);
+
   return (
     <Card.Footer className="p-3 border-top">
       <Form.Group className="mb-2">
@@ -18,24 +37,28 @@ function MessageInput({
           onChange={(e) => setInput(e.target.value)}
           onKeyDown={handleKeyDown}
           placeholder="Type your message here..."
-          rows="2"
+          rows={2}
           disabled={connectionStatus !== 'connected' || isThinking}
         />
       </Form.Group>
       <div className="d-flex justify-content-between align-items-center">
         <div className={`connection-status ${connectionStatus}`}>
-          {connectionStatus.charAt(0).toUpperCase() + connectionStatus.slice(1)}
+          {capitalizedStatus}
         </div>
-        <Button 
+        <Button
           variant="success"
-          onClick={sendMessage} 
-          disabled={connectionStatus !== 'connected' || isThinking}
+          onClick={() => {
+            void onPrimaryAction();
+          }}
+          disabled={connectionStatus !== 'connected' || isThinking || isButtonDisabled}
+          className="d-flex align-items-center gap-2"
         >
-          Send
+          {isProcessingAction && <Spinner animation="border" size="sm" role="status" />}
+          <span>{buttonLabel}</span>
         </Button>
       </div>
     </Card.Footer>
   );
-}
+};
 
-export default MessageInput; 
+export default MessageInput;

--- a/frontend/src/components/chat/MessageList.tsx
+++ b/frontend/src/components/chat/MessageList.tsx
@@ -1,7 +1,19 @@
-import React from 'react';
+import React, { RefObject } from 'react';
 import ReactMarkdown from 'react-markdown';
 
-function MessageList({ messages, messagesEndRef }) {
+type MessageType = 'agent' | 'user' | 'thinking' | 'tool' | 'tool_call' | 'error' | 'signature_pending';
+
+interface ChatMessage {
+  type: MessageType;
+  content: string;
+}
+
+interface MessageListProps {
+  messages: ChatMessage[];
+  messagesEndRef: RefObject<HTMLDivElement>;
+}
+
+const MessageList: React.FC<MessageListProps> = ({ messages, messagesEndRef }) => {
   return (
     <div className="chat-messages p-3 overflow-auto d-flex flex-column">
       {messages.map((message, index) => {
@@ -9,7 +21,7 @@ function MessageList({ messages, messagesEndRef }) {
         return (
           <div className={`message ${message.type} mb-2`} key={index}>
             <div className="message-content">
-              {message.type === "tool" ? (
+              {message.type === 'tool' ? (
                 <pre className="tool-result-pre p-2 rounded">
                   {message.content}
                 </pre>
@@ -23,6 +35,6 @@ function MessageList({ messages, messagesEndRef }) {
       <div ref={messagesEndRef} />
     </div>
   );
-}
+};
 
-export default MessageList; 
+export default MessageList;

--- a/frontend/src/config/abi/MessageManager.json
+++ b/frontend/src/config/abi/MessageManager.json
@@ -1,0 +1,42 @@
+[
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "bytes32",
+            "name": "messageHash",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "address",
+            "name": "payer",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "nonce",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct MessageManager.Message",
+        "name": "m",
+        "type": "tuple"
+      },
+      {
+        "internalType": "bytes",
+        "name": "sig",
+        "type": "bytes"
+      },
+      {
+        "internalType": "string",
+        "name": "messageURI",
+        "type": "string"
+      }
+    ],
+    "name": "payForMessageWithSig",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/frontend/src/config/messageManager.ts
+++ b/frontend/src/config/messageManager.ts
@@ -1,0 +1,28 @@
+import { Address } from 'viem';
+
+export const MESSAGE_MANAGER_ADDRESS = '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC' as Address;
+export const MESSAGE_MANAGER_DOMAIN_NAME = 'MessageManager';
+export const MESSAGE_MANAGER_DOMAIN_VERSION = '1';
+export const MESSAGE_PRICE_USDC = 10_000_000n;
+
+export type MessagePayload = {
+  messageHash: `0x${string}`;
+  payer: Address;
+  nonce: bigint;
+};
+
+export type MessageTypedData = {
+  Message: [
+    { name: 'messageHash'; type: 'bytes32' },
+    { name: 'payer'; type: 'address' },
+    { name: 'nonce'; type: 'uint256' }
+  ];
+};
+
+export const MESSAGE_TYPED_DATA: MessageTypedData = {
+  Message: [
+    { name: 'messageHash', type: 'bytes32' },
+    { name: 'payer', type: 'address' },
+    { name: 'nonce', type: 'uint256' }
+  ]
+};


### PR DESCRIPTION
## Summary
- add MessageManager configuration and ABI for frontend contract calls
- update chat flow to check USDC allowance, request approval, sign typed data, and call payForMessageWithSig before messaging
- refresh chat UI components to support the new pay-or-approve button with loading indicators

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6fca228f0832aa0023a2991340a46